### PR TITLE
Add missing include for ioctl() on linux

### DIFF
--- a/main.c
+++ b/main.c
@@ -33,6 +33,7 @@
 #include <fcntl.h>
 #include <linux/fb.h>
 #include <sys/mman.h>
+#include <sys/ioctl.h>
 #endif
 
 #include "util.h"


### PR DESCRIPTION
```
main.c: In function 'mmap_framebuffer':
main.c:56:9: warning: implicit declaration of function 'ioctl' [-Wimplicit-function-declaration]
     if (ioctl(fd, FBIOGET_FSCREENINFO, &finfo))
         ^
```