### PR TITLE
arm: fix build on Thumb-only architectures

### DIFF
--- a/arm-neon.S
+++ b/arm-neon.S
@@ -21,7 +21,7 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#ifdef __arm__
+#if defined(__arm__) && defined(__ARM_ARCH_ISA_ARM)
 
 .text
 .fpu neon

--- a/asm-opt.c
+++ b/asm-opt.c
@@ -202,7 +202,7 @@ bench_info *get_asm_framebuffer_benchmarks(void)
         return empty;
 }
 
-#elif defined(__arm__)
+#elif defined(__arm__) && defined(__ARM_ARCH_ISA_ARM)
 
 #include "arm-neon.h"
 


### PR DESCRIPTION
Building tinymembench for ARM Cortex-M currently fails, because the
arm-neon.S file contains ARM code that doesn't build on Thumb-only
architectures. To account for this and fix the build for Cortex-M,
this patch adjusts the compile time condition to also verify that the
architecture supports the ARM instruction set, by testing the
__ARM_ARCH_ISA_ARM compiler define.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>