### PR TITLE
add stosb fill

### DIFF
--- a/asm-opt.c
+++ b/asm-opt.c
@@ -129,6 +129,7 @@ static bench_info x86_sse2[] =
 {
     { "MOVSB copy", 0, aligned_block_copy_movsb },
     { "MOVSD copy", 0, aligned_block_copy_movsd },
+	{ "STOSB fill", 0, aligned_block_fill_stosb },
     { "SSE2 copy", 0, aligned_block_copy_sse2 },
     { "SSE2 nontemporal copy", 0, aligned_block_copy_nt_sse2 },
     { "SSE2 copy prefetched (32 bytes step)", 0, aligned_block_copy_pf32_sse2 },

--- a/x86-sse2.S
+++ b/x86-sse2.S
@@ -112,6 +112,26 @@ asm_function aligned_block_copy_movsd
     ret
 .endfunc
 
+asm_function aligned_block_fill_stosb
+0:
+#ifdef __amd64__
+    push3       rdi rsi rcx
+    push3       DST SRC SIZE
+    pop3        rdi rsi rcx
+    mov eax, [rsi + 0]
+    rep stosb
+    pop3        rdi rsi rcx
+#else
+    push3       edi esi ecx
+    push3       DST SRC SIZE
+    pop3        edi esi ecx
+    mov eax, [esi + 0]
+    rep stosb
+    pop3        edi esi ecx
+#endif
+    ret
+.endfunc
+
 asm_function aligned_block_copy_sse2
 0:
     movdqa      xmm0,       [SRC + 0]

--- a/x86-sse2.h
+++ b/x86-sse2.h
@@ -36,6 +36,9 @@ void aligned_block_copy_movsb(int64_t * __restrict dst,
 void aligned_block_copy_movsd(int64_t * __restrict dst,
                               int64_t * __restrict src,
                               int                  size);
+void aligned_block_fill_stosb(int64_t * __restrict dst,
+                              int64_t * __restrict src,
+                              int                  size);
 
 void aligned_block_copy_sse2(int64_t * __restrict dst,
                              int64_t * __restrict src,


### PR DESCRIPTION
Perhaps you would like this small change which adds a `rep stosb` fill test on x86. I found that on Skylake, the `rep stosb` is tied for the best fill with the NT fills, so evidently there is a good (non-temporal) implementation under the covers.