### PR TITLE
Handle memory allocation failure properly, allow to override SIZE, fix declaration compatability.

### DIFF
--- a/main.c
+++ b/main.c
@@ -503,6 +503,13 @@ int main(int argc, char *argv[])
 	    custom_size = SIZE_DEFAULT;
 	}
     }
+    if (argc > 2) {
+       latbench_count = atoi (argv[2]);
+       if ((latbench_count < 100) || (latbench_count > 100*LATBENCH_COUNT)) {
+           printf("WARNING: unexpected count specified, using default instead.\n");
+           latbench_count = LATBENCH_COUNT;
+       }
+    }
     latbench_size = custom_size * 2;
     bufsize = custom_size;
 

--- a/util.c
+++ b/util.c
@@ -337,6 +337,7 @@ void *alloc_four_nonaliased_buffers(void **buf1_, int size1,
 
     ptr = buf = 
         (char *)malloc(size1 + size2 + size3 + size4 + 9 * ALIGN_PADDING);
+    if (!ptr) return ptr;
     memset(buf, 0xCC, size1 + size2 + size3 + size4 + 9 * ALIGN_PADDING);
 
     ptr = align_up(ptr, ALIGN_PADDING);


### PR DESCRIPTION
Handle memory allocation failure properly (instead of producing segfault), allow to override SIZE (mostly needed for smaller devices), fix declaration syntax for older compilers.